### PR TITLE
Update WoopsaExtensions.cs

### DIFF
--- a/Sources/DotNet/Woopsa/Definition/WoopsaExtensions.cs
+++ b/Sources/DotNet/Woopsa/Definition/WoopsaExtensions.cs
@@ -27,8 +27,10 @@ namespace Woopsa
                             return new WoopsaValue((DateTime)value);
                         case WoopsaValueType.TimeSpan:
                             return new WoopsaValue((TimeSpan)value);
-                        case WoopsaValueType.Text:
-                            return new WoopsaValue(value.ToString());
+                        case WoopsaValueType.Text:                            
+                            if (string.IsNullOrEmpty((string)value))
+                                return new WoopsaValue(string.Empty);
+                            return new WoopsaValue(value?.ToString());
                         default:
                             return WoopsaValue.CreateUnchecked(value.ToString(), type);
                     }


### PR DESCRIPTION
Manage null exception if string as a default value.

Maybe it's better to return a 'WoopsaValue.Null' ?
