### PR TITLE
Change RouteHandlerFileSystem file access

### DIFF
--- a/Sources/DotNet/Woopsa/HTTPServer/RouteHandlers/RouteHandlerFileSystem.cs
+++ b/Sources/DotNet/Woopsa/HTTPServer/RouteHandlers/RouteHandlerFileSystem.cs
@@ -87,9 +87,9 @@ namespace Woopsa
             string extension = Path.GetExtension(filePath);
             response.SetHeader(HTTPHeader.ContentType, MIMETypeMap.GetMIMEType(extension));
             response.SetHeader(HTTPHeader.LastModified, System.IO.File.GetLastWriteTime(filePath).ToHTTPDate());
-            FileStream file = File.Open(filePath, FileMode.Open);
-            response.WriteStream(file);
-            file.Close();
+            
+            using (var stream = File.Open(filePath, FileMode.Open, FileAccess.Read, FileShare.Read))
+                response.WriteStream(stream);
         }
     }
 }


### PR DESCRIPTION
Modify 'File.Open' to work in readonly mode, this prevent file concurrency.
Furthermore 'using' syntax is used to correcty release the resource.