### PR TITLE
Rework c# unit tests

### DIFF
--- a/Sources/DotNet/WoopsaTest/UnitTestClasses.cs
+++ b/Sources/DotNet/WoopsaTest/UnitTestClasses.cs
@@ -1,0 +1,165 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Woopsa;
+
+namespace WoopsaTest
+{
+    public class TestObjectServer
+    {
+        public int Votes { get; set; }
+
+        public void IncrementVotes(int count)
+        {
+            Votes += count;
+        }
+    }
+
+    public class TestObjectServerAuthentification
+    {
+        public int Votes { get; set; }
+
+        public void IncrementVotes(int count)
+        {
+            Votes += count;
+        }
+
+        public string CurrentUserName { get { return BaseAuthenticator.CurrentUserName; } }
+    }
+
+    public interface InterfaceA
+    {
+        string A { get; set; }
+
+        void MethodA();
+    }
+
+    public interface InterfaceB : InterfaceA
+    {
+        int B { get; set; }
+
+        void MethodB();
+    }
+
+    public class ClassInterfaceA : InterfaceA
+    {
+        public string A { get; set; }
+
+        public void MethodA() { }
+    }
+
+    public class ClassInterfaceB : InterfaceB
+    {
+        public string A { get; set; }
+        public int B { get; set; }
+
+        public void MethodA() { }
+        public void MethodB() { }
+    }
+
+    public enum Day { Monday, Thursday, Wednesday }
+
+    public class ClassAInner1Inner
+    {
+        public string APropertyString { get; set; }
+
+        [WoopsaVisible(true)]
+        public string APropertyVisible { get; set; }
+
+        [WoopsaVisible(false)]
+        public string APropertyHidden { get; set; }
+
+    }
+
+    public class ClassAInner1
+    {
+        public ClassAInner1()
+        {
+            Inner = new ClassAInner1Inner();
+        }
+
+        public int APropertyInt { get; set; }
+
+        [WoopsaVisible(false)]
+        public int APropertyIntHidden { get; set; }
+
+        [WoopsaVisible(true)]
+        public int APropertyIntVisible { get; set; }
+
+        [WoopsaVisible(true)]
+        public ClassAInner1Inner Inner { get; set; }
+    }
+
+    public class SubClassAInner1 : ClassAInner1
+    {
+        [WoopsaVisible(true)]
+        public int ExtraProperty { get; set; }
+    }
+
+    [WoopsaVisibility(WoopsaVisibility.DefaultIsVisible | WoopsaVisibility.Inherited | WoopsaVisibility.ObjectClassMembers)]
+    public class SubClassAInner2 : SubClassAInner1
+    {
+    }
+
+    public class ClassA
+    {
+        public ClassA()
+        {
+            Inner1 = new ClassAInner1();
+        }
+        public bool APropertyBool { get; set; }
+
+        [WoopsaVisible(false)]
+        public DateTime APropertyDateTime { get; set; }
+        public DateTime APropertyDateTime2 { get; set; }
+
+        [WoopsaVisible(true)]
+        public ClassAInner1 Inner1 { get; set; }
+
+        public Day Day { get; set; }
+    }
+
+    [WoopsaVisibility(WoopsaVisibility.DefaultIsVisible | WoopsaVisibility.Inherited | WoopsaVisibility.MethodSpecialName)]
+    public class ClassB : ClassA
+    {
+        public int APropertyInt { get; set; }
+
+        double APropertyDouble { get; set; }
+    }
+
+    [WoopsaVisibility(WoopsaVisibility.None)]
+    public class ClassC : ClassB
+    {
+        [WoopsaVisible]
+        [WoopsaValueType(WoopsaValueType.Integer)]
+        public string APropertyText { get; set; }
+
+        [WoopsaVisible]
+        public TimeSpan APropertyTimeSpan { get; set; }
+
+        // This one must not be published (private)
+        [WoopsaVisible]
+        private double APropertyDouble2 { get; set; }
+
+        [WoopsaVisible]
+        [WoopsaValueType(WoopsaValueType.JsonData)]
+        public string APropertyJson { get; set; }
+    }
+
+    public class ClassD
+    {
+        public ClassD(int n) { APropertyInt = n; }
+        public int APropertyInt { get; set; }
+    }
+
+    public class ClassE
+    {
+        public ClassE()
+        {
+        }
+
+        public Day Day { get; set; }
+    }
+}

--- a/Sources/DotNet/WoopsaTest/UnitTestWoopsaDynamicNotification.cs
+++ b/Sources/DotNet/WoopsaTest/UnitTestWoopsaDynamicNotification.cs
@@ -13,18 +13,25 @@ namespace WoopsaTest
     [TestClass]
     public class UnitTestWoopsaDynamicNotification
     {
+        #region Consts
+
+        public const int TestingPort = 9999;
+        public static string TestingUrl => $"http://localhost:{TestingPort}/woopsa";
+
         const int QUEUE_SIZE = 1000;
         const int MONITOR_INTERVAL = 10;
         const int PUBLISH_INTERVAL = 10;
+
+        #endregion
 
         [TestMethod]
         public void TestWoopsaDynamicNotification()
         {
             TestObjectServer objectServer = new TestObjectServer();
-            using (WoopsaServer server = new WoopsaServer(objectServer))
+            using (WoopsaServer server = new WoopsaServer(objectServer, TestingPort))
             {
                 // Solution with dynamic client
-                using (dynamic dynamicClient = new WoopsaDynamicClient("http://localhost/woopsa"))
+                using (dynamic dynamicClient = new WoopsaDynamicClient(TestingUrl))
                 {
                     int channel = dynamicClient.SubscriptionService.CreateSubscriptionChannel(QUEUE_SIZE);
                     // Subscription for a valid variable
@@ -85,15 +92,14 @@ namespace WoopsaTest
             }
         } //end TestWoopsaDynamicNotification
 
-
         [TestMethod]
         public void TestWoopsaDynamicNotificationUnexistingProperty()
         {
             TestObjectServer objectServer = new TestObjectServer();
-            using (WoopsaServer server = new WoopsaServer(objectServer))
+            using (WoopsaServer server = new WoopsaServer(objectServer, TestingPort))
             {
                 // Solution with dynamic client
-                using (dynamic dynamicClient = new WoopsaDynamicClient("http://localhost/woopsa"))
+                using (dynamic dynamicClient = new WoopsaDynamicClient(TestingUrl))
                 {
                     int channel = dynamicClient.SubscriptionService.CreateSubscriptionChannel(QUEUE_SIZE);
                     // Subscription for an nonexistent variable (should work)
@@ -128,6 +134,5 @@ namespace WoopsaTest
                 }
             }
         } //end TestWoopsaDynamicNotification
-
     }
 }

--- a/Sources/DotNet/WoopsaTest/UnitTestWoopsaMultiRequest.cs
+++ b/Sources/DotNet/WoopsaTest/UnitTestWoopsaMultiRequest.cs
@@ -5,34 +5,50 @@ using System.Collections.Generic;
 
 namespace WoopsaTest
 {
-    public class TestObjectMultiRequest
-    {
-        public double A { get; set; }
-        public double B { get; set; }
-        public string S { get; set; }
-
-        public double Sum { get { return A + B; } }
-
-        public void Set(double a, double b)
-        {
-            A = a;
-            B = b;
-        }
-
-        public void SetS(string value)
-        {
-            S = value;
-        }
-
-        public void Click() { IsClicked = true; }
-
-        public bool IsClicked { get; set; }
-    }
-
     [TestClass]
     public class UnitTestWoopsaMultiRequest
     {
-        public void ExecuteMultiRequestTestSerie(WoopsaClient client, TestObjectMultiRequest objectServer)
+        #region Consts
+
+        public const int TestingPort = 9999;
+        public static string TestingUrl => $"http://localhost:{TestingPort}/woopsa";
+        
+        #endregion
+
+        [TestMethod]
+        public void TestWoopsaMultiRequest()
+        {
+            WoopsaObject serverRoot = new WoopsaObject(null, "");
+            TestObjectMultiRequest objectServer = new TestObjectMultiRequest();
+            WoopsaObjectAdapter adapter = new WoopsaObjectAdapter(serverRoot, "TestObject", objectServer);
+            using (WoopsaServer server = new WoopsaServer(serverRoot, TestingPort))
+            {
+                using (WoopsaClient client = new WoopsaClient(TestingUrl))
+                {
+                    ExecuteMultiRequestTestSerie(client, objectServer);
+                }
+            }
+        }
+
+        [TestMethod]
+        public void TestWoopsaMultiRequestNoRemoteMultiRequestService()
+        {
+            WoopsaObject serverRoot = new WoopsaObject(null, "");
+            TestObjectMultiRequest objectServer = new TestObjectMultiRequest();
+            WoopsaObjectAdapter adapter = new WoopsaObjectAdapter(serverRoot, "TestObject", objectServer);
+            using (WoopsaServer server = new WoopsaServer((IWoopsaContainer)serverRoot, TestingPort))
+            {
+                using (WoopsaClient client = new WoopsaClient(TestingUrl))
+                {
+                    ExecuteMultiRequestTestSerie(client, objectServer);
+                }
+            }
+
+        }
+
+        #region Private Members
+
+        private void ExecuteMultiRequestTestSerie(WoopsaClient client, TestObjectMultiRequest objectServer)
         {
             WoopsaClientMultiRequest multiRequest = new WoopsaClientMultiRequest();
 
@@ -44,8 +60,8 @@ namespace WoopsaTest
 
             WoopsaMethodArgumentInfo[] argumentInfosSet = new WoopsaMethodArgumentInfo[]
             {
-                        new WoopsaMethodArgumentInfo("a", WoopsaValueType.Real),
-                        new WoopsaMethodArgumentInfo("b", WoopsaValueType.Real)
+                new WoopsaMethodArgumentInfo("a", WoopsaValueType.Real),
+                new WoopsaMethodArgumentInfo("b", WoopsaValueType.Real)
             };
             WoopsaClientRequest request6 = multiRequest.Invoke("TestObject/Set",
                 argumentInfosSet, 4, 5);
@@ -58,7 +74,7 @@ namespace WoopsaTest
 
             WoopsaMethodArgumentInfo[] argumentInfosSetS = new WoopsaMethodArgumentInfo[]
             {
-                        new WoopsaMethodArgumentInfo("value", WoopsaValueType.Text)
+                new WoopsaMethodArgumentInfo("value", WoopsaValueType.Text)
             };
             WoopsaClientRequest request12 = multiRequest.Invoke("TestObject/SetS",
                 argumentInfosSetS, "Hello");
@@ -98,35 +114,34 @@ namespace WoopsaTest
 
         }
 
-        [TestMethod]
-        public void TestWoopsaMultiRequest()
-        {
-            WoopsaObject serverRoot = new WoopsaObject(null, "");
-            TestObjectMultiRequest objectServer = new TestObjectMultiRequest();
-            WoopsaObjectAdapter adapter = new WoopsaObjectAdapter(serverRoot, "TestObject", objectServer);
-            using (WoopsaServer server = new WoopsaServer(serverRoot))
-            {
-                using (WoopsaClient client = new WoopsaClient("http://localhost/woopsa"))
-                {
-                    ExecuteMultiRequestTestSerie(client, objectServer);
-                }
-            }
-        }
+        #endregion
 
-        [TestMethod]
-        public void TestWoopsaMultiRequestNoRemoteMultiRequestService()
+        #region Inner classes
+
+        public class TestObjectMultiRequest
         {
-            WoopsaObject serverRoot = new WoopsaObject(null, "");
-            TestObjectMultiRequest objectServer = new TestObjectMultiRequest();
-            WoopsaObjectAdapter adapter = new WoopsaObjectAdapter(serverRoot, "TestObject", objectServer);
-            using (WoopsaServer server = new WoopsaServer((IWoopsaContainer)serverRoot))
+            public double A { get; set; }
+            public double B { get; set; }
+            public string S { get; set; }
+
+            public double Sum { get { return A + B; } }
+
+            public void Set(double a, double b)
             {
-                using (WoopsaClient client = new WoopsaClient("http://localhost/woopsa"))
-                {
-                    ExecuteMultiRequestTestSerie(client, objectServer);
-                }
+                A = a;
+                B = b;
             }
 
+            public void SetS(string value)
+            {
+                S = value;
+            }
+
+            public void Click() { IsClicked = true; }
+
+            public bool IsClicked { get; set; }
         }
+
+        #endregion
     }
 }

--- a/Sources/DotNet/WoopsaTest/UnitTestWoopsaNotification.cs
+++ b/Sources/DotNet/WoopsaTest/UnitTestWoopsaNotification.cs
@@ -13,14 +13,20 @@ namespace WoopsaTest
     [TestClass]
     public class UnitTestWoopsaNotification
     {
+        #region Consts
+
+        public const int TestingPort = 9999;
+        public static string TestingUrl => $"http://localhost:{TestingPort}/woopsa";
+
+        #endregion
 
         [TestMethod]
         public void TestWoopsaWaitNotification()
         {
             TestObjectServer objectServer = new TestObjectServer();
-            using (WoopsaServer server = new WoopsaServer(objectServer))
+            using (WoopsaServer server = new WoopsaServer(objectServer, TestingPort))
             {
-                using (WoopsaClient client = new WoopsaClient("http://localhost/woopsa"))
+                using (WoopsaClient client = new WoopsaClient(TestingUrl))
                 {
                     WoopsaBoundClientObject root = client.CreateBoundRoot();
                     // Just to show how to see all items

--- a/Sources/DotNet/WoopsaTest/UnitTestWoopsaObject.cs
+++ b/Sources/DotNet/WoopsaTest/UnitTestWoopsaObject.cs
@@ -9,8 +9,6 @@ namespace WoopsaTest
     [TestClass]
     public class UnitTestWoopsaObject
     {
-        private double _minLevel, _maxLevel;
-
         [TestMethod]
         public void TestWoopsaObjects()
         {
@@ -52,20 +50,13 @@ namespace WoopsaTest
             Assert.AreEqual(_maxLevel, 5.5);
         }
 
-        private WoopsaValue Calibrate(System.Collections.Generic.IEnumerable<IWoopsaValue> Arguments)
-        {
-            _minLevel = Arguments.ElementAt(0).ToDouble();
-            _maxLevel = Arguments.ElementAt(1).ToDouble();
-            return WoopsaValue.Null;
-        }
-
         [TestMethod]
         public void TestWoopsaObjectPerformance()
         {
-            const int ObjectCount = 5000;
-            const int AccessCount = 50000;
+            const int objectCount = 5000;
+            const int accessCount = 50000;
             WoopsaRoot root = new WoopsaRoot();
-            for (int i = 0; i < ObjectCount; i++)
+            for (int i = 0; i < objectCount; i++)
             {
                 WoopsaObject newObject = new WoopsaObject(root, "Item" + i.ToString());
                 int x = i;
@@ -73,11 +64,24 @@ namespace WoopsaTest
             }
             Stopwatch watch = new Stopwatch();
             watch.Start();
-            for (int i = 0; i < AccessCount; i++)
+            for (int i = 0; i < accessCount; i++)
             {
-                int k = ((WoopsaProperty)(root.ByPath("Item" + (ObjectCount - 1).ToString() + "/Data"))).Value.ToInt32();
+                int k = ((WoopsaProperty)(root.ByPath("Item" + (objectCount - 1).ToString() + "/Data"))).Value.ToInt32();
             }
             Assert.IsTrue(watch.ElapsedMilliseconds < 1000);
         }
+
+        #region Private Members
+
+        private WoopsaValue Calibrate(System.Collections.Generic.IEnumerable<IWoopsaValue> arguments)
+        {
+            _minLevel = arguments.ElementAt(0).ToDouble();
+            _maxLevel = arguments.ElementAt(1).ToDouble();
+            return WoopsaValue.Null;
+        }
+
+        private double _minLevel, _maxLevel; 
+
+        #endregion
     }
 }

--- a/Sources/DotNet/WoopsaTest/UnitTestWoopsaObjectAdapter.cs
+++ b/Sources/DotNet/WoopsaTest/UnitTestWoopsaObjectAdapter.cs
@@ -6,126 +6,12 @@ using System.Collections.Generic;
 
 namespace WoopsaTest
 {
-    public enum Day { Monday, Thursday, Wednesday }
-
-    public class ClassAInner1Inner
-    {
-        public string APropertyString { get; set; }
-
-        [WoopsaVisible(true)]
-        public string APropertyVisible { get; set; }
-
-        [WoopsaVisible(false)]
-        public string APropertyHidden { get; set; }
-
-    }
-
-    public class ClassAInner1
-    {
-        public ClassAInner1()
-        {
-            Inner = new ClassAInner1Inner();
-        }
-
-        public int APropertyInt { get; set; }
-
-        [WoopsaVisible(false)]
-        public int APropertyIntHidden { get; set; }
-
-        [WoopsaVisible(true)]
-        public int APropertyIntVisible { get; set; }
-
-        [WoopsaVisible(true)]
-        public ClassAInner1Inner Inner { get; set; }
-
-    }
-
-
-    public class SubClassAInner1 : ClassAInner1
-    {
-        [WoopsaVisible(true)]
-        public int ExtraProperty { get; set; }
-
-    }
-
-    [WoopsaVisibility(WoopsaVisibility.DefaultIsVisible | WoopsaVisibility.Inherited | WoopsaVisibility.ObjectClassMembers)]
-    public class SubClassAInner2 : SubClassAInner1
-    {
-
-    }
-
-
-    public class ClassA
-    {
-        public ClassA()
-        {
-            Inner1 = new ClassAInner1();
-        }
-        public bool APropertyBool { get; set; }
-
-        [WoopsaVisible(false)]
-        public DateTime APropertyDateTime { get; set; }
-        public DateTime APropertyDateTime2 { get; set; }
-
-        [WoopsaVisible(true)]
-        public ClassAInner1 Inner1 { get; set; }
-
-        public Day Day { get; set; }
-
-    }
-
-    [WoopsaVisibility(WoopsaVisibility.DefaultIsVisible | WoopsaVisibility.Inherited | WoopsaVisibility.MethodSpecialName)]
-    public class ClassB : ClassA
-    {
-        public int APropertyInt { get; set; }
-
-        double APropertyDouble { get; set; }
-    }
-
-    [WoopsaVisibility(WoopsaVisibility.None)]
-    public class ClassC : ClassB
-    {
-        [WoopsaVisible]
-        [WoopsaValueType(WoopsaValueType.Integer)]
-        public string APropertyText { get; set; }
-
-        [WoopsaVisible]
-        public TimeSpan APropertyTimeSpan { get; set; }
-
-        // This one must not be published (private)
-        [WoopsaVisible]
-        private double APropertyDouble2 { get; set; }
-
-        [WoopsaVisible]
-        [WoopsaValueType(WoopsaValueType.JsonData)]
-        public string APropertyJson { get; set; }
-
-
-    }
-
-    public class ClassD
-    {
-        public ClassD(int n) { APropertyInt = n; }
-        public int APropertyInt { get; set; }
-    }
-
-    public class ClassE
-    {
-        public ClassE()
-        {
-        }
-
-        public Day Day { get; set; }
-
-    }
-
     [TestClass]
     public class UnitTestWoopsaObjectAdapter
     {
         [TestMethod]
         public void TestWoopsaObjectAdapter()
         {
-
             ClassA a = new ClassA();
             WoopsaObjectAdapter adapterA1 = new WoopsaObjectAdapter(null, "a", a);
             Assert.IsNotNull(adapterA1.Properties.ByNameOrNull(nameof(a.APropertyBool)));
@@ -463,37 +349,7 @@ namespace WoopsaTest
                 WoopsaVisibility.ListClassMembers);
             Assert.AreEqual(adapterList2.Items.Count, 1); // List "Item" indexer
         }
-
-        public interface InterfaceA
-        {
-            string A { get; set; }
-
-            void MethodA();
-        }
-
-        public interface InterfaceB : InterfaceA
-        {
-            int B { get; set; }
-
-            void MethodB();
-        }
-
-        public class ClassInterfaceA : InterfaceA
-        {
-            public string A { get; set; }
-
-            public void MethodA() { }
-        }
-
-        public class ClassInterfaceB : InterfaceB
-        {
-            public string A { get; set; }
-            public int B { get; set; }
-
-            public void MethodA() { }
-            public void MethodB() { }
-        }
-
+       
         [TestMethod]
         public void TestWoopsaObjectAdapterInterfaces()
         {
@@ -518,7 +374,5 @@ namespace WoopsaTest
             Assert.IsNotNull(adapterB2.Properties.ByNameOrNull(nameof(InterfaceA.A)));
             Assert.IsNotNull(adapterB2.Methods.ByNameOrNull(nameof(InterfaceA.MethodA)));
         }
-
-
     }
 }

--- a/Sources/DotNet/WoopsaTest/UnitTestWoopsaProtocol.cs
+++ b/Sources/DotNet/WoopsaTest/UnitTestWoopsaProtocol.cs
@@ -7,22 +7,15 @@ using System.Collections.Specialized;
 
 namespace WoopsaTest
 {
-    public class TestObjectServer
-    {
-        public int Votes { get; set; }
-
-        public void IncrementVotes(int count)
-        {
-            Votes += count;
-        }
-
-    }
-
-
-
     [TestClass]
     public class UnitTestWoopsaProtocol
     {
+        #region Consts
+
+        public const int TestingPort = 9999;
+        public static string TestingUrl => $"http://localhost:{TestingPort}/woopsa";
+
+        #endregion
 
         [TestMethod]
         public void TestWoopsaProtocolRootContainer()
@@ -30,9 +23,9 @@ namespace WoopsaTest
             WoopsaRoot serverRoot = new WoopsaRoot();
             TestObjectServer objectServer = new TestObjectServer();
             WoopsaObjectAdapter adapter = new WoopsaObjectAdapter(serverRoot, "TestObject", objectServer);
-            using (WoopsaServer server = new WoopsaServer(serverRoot))
+            using (WoopsaServer server = new WoopsaServer(serverRoot, TestingPort))
             {
-                using (WoopsaClient client = new WoopsaClient("http://localhost/woopsa"))
+                using (WoopsaClient client = new WoopsaClient(TestingUrl))
                 {
                     WoopsaBoundClientObject root = client.CreateBoundRoot();
                     (root.Items.ByName("TestObject") as WoopsaObject).Properties.ByName("Votes").Value = 17;
@@ -45,9 +38,9 @@ namespace WoopsaTest
         public void TestWoopsaProtocol()
         {
             TestObjectServer objectServer = new TestObjectServer();
-            using (WoopsaServer server = new WoopsaServer(objectServer))
+            using (WoopsaServer server = new WoopsaServer(objectServer, TestingPort))
             {
-                using (WoopsaClient client = new WoopsaClient("http://localhost/woopsa"))
+                using (WoopsaClient client = new WoopsaClient(TestingUrl))
                 {
                     WoopsaBoundClientObject root = client.CreateBoundRoot();
                     root.Properties.ByName("Votes").Value = new WoopsaValue(11);
@@ -72,11 +65,11 @@ namespace WoopsaTest
         public void TestWoopsaProtocolUnboundClient()
         {
             TestObjectServer objectServer = new TestObjectServer();
-            using (WoopsaClient client = new WoopsaClient("http://localhost/woopsa"))
+            using (WoopsaClient client = new WoopsaClient(TestingUrl))
             {
                 WoopsaUnboundClientObject root = client.CreateUnboundRoot("root");
                 WoopsaProperty propertyVote = root.GetProperty("Votes", WoopsaValueType.Integer, false);
-                using (WoopsaServer server = new WoopsaServer(objectServer))
+                using (WoopsaServer server = new WoopsaServer(objectServer, TestingPort))
                 {
                     propertyVote.Value = new WoopsaValue(123);
                     Assert.AreEqual(objectServer.Votes, 123);
@@ -90,9 +83,9 @@ namespace WoopsaTest
         public void TestWoopsaProtocolPerformance()
         {
             TestObjectServer objectServer = new TestObjectServer();
-            using (WoopsaServer server = new WoopsaServer(objectServer))
+            using (WoopsaServer server = new WoopsaServer(objectServer, TestingPort))
             {
-                using (WoopsaClient client = new WoopsaClient("http://localhost/woopsa"))
+                using (WoopsaClient client = new WoopsaClient(TestingUrl))
                 {
                     WoopsaBoundClientObject root = client.CreateBoundRoot();
                     IWoopsaProperty property = root.Properties.ByName("Votes");
@@ -118,9 +111,9 @@ namespace WoopsaTest
         public void TestWoopsaServerPerformance()
         {
             TestObjectServer objectServer = new TestObjectServer();
-            using (WoopsaServer server = new WoopsaServer(objectServer))
+            using (WoopsaServer server = new WoopsaServer(objectServer, TestingPort))
             {
-                using (dynamic dynamicClient = new WoopsaDynamicClient("http://localhost/woopsa"))
+                using (dynamic dynamicClient = new WoopsaDynamicClient(TestingUrl))
                 {
                     Stopwatch watch = new Stopwatch();
                     watch.Start();
@@ -140,37 +133,23 @@ namespace WoopsaTest
                     //				dynamicClient.Votes.Change += new EventHandler<WoopsaNotificationEventArgs>((o, e) => Console.WriteLine("Value : {0}", e.Value.ToInt32()));
                     //		Thread.Sleep(100);
                     //	dynamicClient.Votes = 15;
-                    //			WoopsaClient client = new WoopsaClient("http://localhost/woopsa");
+                    //			WoopsaClient client = new WoopsaClient(TestingUrl);
                     //				int votes = client.Properties.ByName("Votes").Value.ToInt32();
                     //				client.Properties.ByName("Votes");
                 }
             }
         }
 
-        public class TestObjectServerAuthentification
-        {
-            public int Votes { get; set; }
-
-            public void IncrementVotes(int count)
-            {
-                Votes += count;
-            }
-
-            public string CurrentUserName { get { return BaseAuthenticator.CurrentUserName; } }
-
-        }
-
-
         [TestMethod]
         public void TestWoopsaServerAuthentication()
         {
             TestObjectServerAuthentification objectServer = new TestObjectServerAuthentification();
-            using (WoopsaServer server = new WoopsaServer(objectServer))
+            using (WoopsaServer server = new WoopsaServer(objectServer, TestingPort))
             {
                 server.Authenticator = new SimpleAuthenticator("TestRealm",
                     (sender, e) => { e.IsAuthenticated = e.Username=="woopsa"; });
 
-                using (WoopsaClient client = new WoopsaClient("http://localhost/woopsa"))
+                using (WoopsaClient client = new WoopsaClient(TestingUrl))
                 {
                     const string TestUserName ="woopsa";
                     client.Username = TestUserName;

--- a/Sources/DotNet/WoopsaTest/WoopsaTest.csproj
+++ b/Sources/DotNet/WoopsaTest/WoopsaTest.csproj
@@ -57,6 +57,7 @@
     </Otherwise>
   </Choose>
   <ItemGroup>
+    <Compile Include="UnitTestClasses.cs" />
     <Compile Include="UnitTestWoopsaMultiRequest.cs" />
     <Compile Include="UnitTestWoopsaDynamicNotification.cs" />
     <Compile Include="UnitTestWoopsaNotification.cs" />


### PR DESCRIPTION
clean up tests, and use a specific port to avoid collision with CI server.