### PR TITLE
Serve Embedded resource : Support of space in Assembly name by replacing space to "_".

### DIFF
--- a/Sources/DotNet/Woopsa/HTTPServer/RouteHandlers/RouteHandlerEmbeddedResources.cs
+++ b/Sources/DotNet/Woopsa/HTTPServer/RouteHandlers/RouteHandlerEmbeddedResources.cs
@@ -123,7 +123,8 @@ namespace Woopsa
 
         private string FullResourceName(Assembly assembly, string strippedResourceName)
         {
-            return string.Format("{0}.{1}", assembly.GetName().Name, strippedResourceName);
+            string safeDefaultNamesapceFromAssemblyName = assembly.GetName().Name.Replace(" ", "_");
+            return string.Format("{0}.{1}", safeDefaultNamesapceFromAssemblyName, strippedResourceName);
         }
 
         private Assembly AssemblyByName(string name)


### PR DESCRIPTION
When creating a project in visual studio with space in its name, the assembly name corresponds to the project name but the Default Namespace is transform to safe project name by replacing space to "_". To access embedded resource using the assembly name, this default namespace must correspond to the assembly name. This correction prevents difficult and time-consuming resolution.