### PR TITLE
Fix issue The server committed a protocol violation. …

### DIFF
--- a/Sources/DotNet/Woopsa/HTTPServer/Utils/HTTPResponse.cs
+++ b/Sources/DotNet/Woopsa/HTTPServer/Utils/HTTPResponse.cs
@@ -63,8 +63,16 @@ namespace Woopsa
         /// that will be sent to the client. This is the text that immediately follows
         /// the Status Code in an HTTP response, such as "200 OK" or "404 Not Found"
         /// </summary>
-        public string ResponseMessage { get; private set; }
-
+        public string ResponseMessage 
+        { 
+            get => _responseMessage;
+            private set 
+            { 
+                CheckForNotSupportedchar(value);
+                _responseMessage = value;
+            }
+        }
+        private string _responseMessage;
         /// <summary>
         /// Mainly used for debugging, this property returns the length, in bytes,
         /// of the response content that will be sent to the client (excluding headers).
@@ -93,6 +101,7 @@ namespace Woopsa
         /// </param>
         public void SetHeader(string header, string value)
         {
+            CheckForNotSupportedchar(value);
             _headers[header] = value;
         }
 
@@ -218,6 +227,12 @@ namespace Woopsa
         #endregion
 
         #region Private/Protected/Internal Methods
+        private void CheckForNotSupportedchar(string value)
+        {
+            if (value.Contains("\r\n") || value.Contains('\n') || value.Contains('\r'))
+                throw new Exception($"Value {value} contains not supported char such as \\n\\r, \\n or \\r");
+        }
+
         private void SetHeaderIfNotExists(string header, string value)
         {
             if (!_headers.ContainsKey(header))

--- a/Sources/DotNet/Woopsa/Protocol/WoopsaServer.cs
+++ b/Sources/DotNet/Woopsa/Protocol/WoopsaServer.cs
@@ -350,25 +350,25 @@ namespace Woopsa
             }
             catch (WoopsaNotFoundException e)
             {
-                response.WriteError(HTTPStatusCode.NotFound, e.GetFullMessage().Replace(Environment.NewLine, " "), 
+                response.WriteError(HTTPStatusCode.NotFound, RemoveNotAllowedChar(e.GetFullMessage()), 
                     e.Serialize(), MIMETypes.Application.JSON);
                 OnHandledException(e);
             }
             catch (WoopsaInvalidOperationException e)
             {
-                response.WriteError(HTTPStatusCode.BadRequest, e.GetFullMessage().Replace(Environment.NewLine, " "), 
+                response.WriteError(HTTPStatusCode.BadRequest, RemoveNotAllowedChar(e.GetFullMessage()), 
                     e.Serialize(), MIMETypes.Application.JSON);
                 OnHandledException(e);
             }
             catch (WoopsaException e)
             {
-                response.WriteError(HTTPStatusCode.InternalServerError, e.GetFullMessage().Replace(Environment.NewLine, " "), 
+                response.WriteError(HTTPStatusCode.InternalServerError, RemoveNotAllowedChar(e.GetFullMessage()), 
                     e.Serialize(), MIMETypes.Application.JSON);
                 OnHandledException(e);
             }
             catch (Exception e)
             {
-                response.WriteError(HTTPStatusCode.InternalServerError, e.GetFullMessage().Replace(Environment.NewLine, " "), 
+                response.WriteError(HTTPStatusCode.InternalServerError, RemoveNotAllowedChar(e.GetFullMessage()), 
                     e.Serialize(), MIMETypes.Application.JSON);
                 OnHandledException(e);
             }
@@ -534,6 +534,8 @@ namespace Woopsa
         {
             return _root.ByPath(searchPath);
         }
+        private string RemoveNotAllowedChar(string text) =>
+            text.Replace("\r\n", " ").Replace('\n', ' ').Replace('\r', ' ');
 
         #endregion
 

--- a/Sources/DotNet/Woopsa/Protocol/WoopsaServer.cs
+++ b/Sources/DotNet/Woopsa/Protocol/WoopsaServer.cs
@@ -350,22 +350,26 @@ namespace Woopsa
             }
             catch (WoopsaNotFoundException e)
             {
-                response.WriteError(HTTPStatusCode.NotFound, e.GetFullMessage(), e.Serialize(), MIMETypes.Application.JSON);
+                response.WriteError(HTTPStatusCode.NotFound, e.GetFullMessage().Replace(Environment.NewLine, " "), 
+                    e.Serialize(), MIMETypes.Application.JSON);
                 OnHandledException(e);
             }
             catch (WoopsaInvalidOperationException e)
             {
-                response.WriteError(HTTPStatusCode.BadRequest, e.GetFullMessage(), e.Serialize(), MIMETypes.Application.JSON);
+                response.WriteError(HTTPStatusCode.BadRequest, e.GetFullMessage().Replace(Environment.NewLine, " "), 
+                    e.Serialize(), MIMETypes.Application.JSON);
                 OnHandledException(e);
             }
             catch (WoopsaException e)
             {
-                response.WriteError(HTTPStatusCode.InternalServerError, e.GetFullMessage(), e.Serialize(), MIMETypes.Application.JSON);
+                response.WriteError(HTTPStatusCode.InternalServerError, e.GetFullMessage().Replace(Environment.NewLine, " "), 
+                    e.Serialize(), MIMETypes.Application.JSON);
                 OnHandledException(e);
             }
             catch (Exception e)
             {
-                response.WriteError(HTTPStatusCode.InternalServerError, e.GetFullMessage(), e.Serialize(), MIMETypes.Application.JSON);
+                response.WriteError(HTTPStatusCode.InternalServerError, e.GetFullMessage().Replace(Environment.NewLine, " "), 
+                    e.Serialize(), MIMETypes.Application.JSON);
                 OnHandledException(e);
             }
         }


### PR DESCRIPTION
Section=Response Header Detail=CR must be followed by LF

Occurs when exception message raised during invocation had some "\n\r" inside. These unsupported chars are now removed.

Message before : ![ViolationException](https://user-images.githubusercontent.com/26797887/107061319-52855a00-67d8-11eb-8f7e-9bb175698198.png)

Message now : 
![Exception message without NewLine](https://user-images.githubusercontent.com/26797887/107061385-6c26a180-67d8-11eb-8945-281cb3a84ce3.png)
