### PR TITLE
Error Uri is too long 

### DIFF
--- a/Sources/DotNet/Woopsa/Client/WoopsaClientProtocol.cs
+++ b/Sources/DotNet/Woopsa/Client/WoopsaClientProtocol.cs
@@ -5,7 +5,6 @@ using System.Linq;
 using System.Net;
 using System.Net.Http;
 using System.Text;
-using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
 

--- a/Sources/DotNet/Woopsa/Client/WoopsaClientProtocol.cs
+++ b/Sources/DotNet/Woopsa/Client/WoopsaClientProtocol.cs
@@ -205,6 +205,37 @@ namespace Woopsa
             return collection.AllKeys.Select(key => new KeyValuePair<string, string>(key, collection[key]));
         }
 
+        // Note : Replace FormUrlEncodedContent that has uri size limitations
+        private static StringContent FormUrlEncode(NameValueCollection postData)
+        {
+            int limit = 2000;
+            return new StringContent(postData.AllKeys.Aggregate(new StringBuilder(), (sb, nxt) =>
+            {
+                StringBuilder sbInternal = new StringBuilder();
+
+                if (sb.Length > 0)
+                {
+                    sb.Append("&");
+                }
+                string value = postData[nxt];
+                int loops = value.Length / limit;
+
+                for (int i = 0; i <= loops; i++)
+                {
+                    if (i < loops)
+                    {
+                        sbInternal.Append(Uri.EscapeDataString(value.Substring(limit * i, limit)));
+                    }
+                    else
+                    {
+                        sbInternal.Append(Uri.EscapeDataString(value.Substring(limit * i)));
+                    }
+                }
+
+                return sb.Append(nxt + "=" + sbInternal.ToString());
+            }).ToString(), Encoding.UTF8, "application/x-www-form-urlencoded");
+        }
+
         private async Task<string> RequestAsync(string path, NameValueCollection postData, TimeSpan timeout)
         {
             if (!_terminating)
@@ -221,18 +252,8 @@ namespace Woopsa
                         if (postData == null)
                             response = await client.GetAsync(requestUrl, HttpCompletionOption.ResponseHeadersRead, cancellationTokenSource.Token);
                         else
-                        {
-                            HttpContent content = null;
-                            try
-                            {
-                                content = new FormUrlEncodedContent(ToPairs(postData));
-                            }
-                            catch (UriFormatException)
-                            {
-                                content = new StringContent(JsonSerializer.Serialize(ToPairs(postData)), Encoding.UTF8, MIMETypes.Application.JSON);
-                            }
-                            response = await client.PostAsync(requestUrl, content, cancellationTokenSource.Token);
-                        }
+                            response = await client.PostAsync(requestUrl, FormUrlEncode(postData), cancellationTokenSource.Token);
+                        
                         SetLastCommunicationSuccessful(true);
                     }
                     catch (Exception)

--- a/Sources/DotNet/Woopsa/Client/WoopsaClientProtocol.cs
+++ b/Sources/DotNet/Woopsa/Client/WoopsaClientProtocol.cs
@@ -4,6 +4,8 @@ using System.Collections.Specialized;
 using System.Linq;
 using System.Net;
 using System.Net.Http;
+using System.Text;
+using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -220,7 +222,15 @@ namespace Woopsa
                             response = await client.GetAsync(requestUrl, HttpCompletionOption.ResponseHeadersRead, cancellationTokenSource.Token);
                         else
                         {
-                            HttpContent content = new FormUrlEncodedContent(ToPairs(postData));
+                            HttpContent content = null;
+                            try
+                            {
+                                content = new FormUrlEncodedContent(ToPairs(postData));
+                            }
+                            catch (UriFormatException)
+                            {
+                                content = new StringContent(JsonSerializer.Serialize(ToPairs(postData)), Encoding.UTF8, MIMETypes.Application.JSON);
+                            }
                             response = await client.PostAsync(requestUrl, content, cancellationTokenSource.Token);
                         }
                         SetLastCommunicationSuccessful(true);

--- a/Sources/DotNet/WoopsaTest/UnitTestWoopsaMultiRequest.cs
+++ b/Sources/DotNet/WoopsaTest/UnitTestWoopsaMultiRequest.cs
@@ -31,6 +31,21 @@ namespace WoopsaTest
         }
 
         [TestMethod]
+        public void TestWoopsaHugeMultiRequest()
+        {
+            WoopsaObject serverRoot = new WoopsaObject(null, "");
+            TestObjectMultiRequest objectServer = new TestObjectMultiRequest();
+            WoopsaObjectAdapter adapter = new WoopsaObjectAdapter(serverRoot, "TestObject", objectServer);
+            using (WoopsaServer server = new WoopsaServer(serverRoot, TestingPort))
+            {
+                using (WoopsaClient client = new WoopsaClient(TestingUrl))
+                {
+                    ExecuteHugeMultiRequestTestSerie(client, objectServer);
+                }
+            }
+        }
+
+        [TestMethod]
         public void TestWoopsaMultiRequestNoRemoteMultiRequestService()
         {
             WoopsaObject serverRoot = new WoopsaObject(null, "");
@@ -114,6 +129,44 @@ namespace WoopsaTest
 
         }
 
+        private void ExecuteHugeMultiRequestTestSerie(WoopsaClient client, TestObjectMultiRequest objectServer)
+        {
+            WoopsaClientMultiRequest multiRequest = new WoopsaClientMultiRequest();
+            for (int i = 0; i < 200; i++) // ~200 X 15 requests
+            {
+                multiRequest.Write("TestObject/A", 1);
+                multiRequest.Write("TestObject/B", 2);
+                multiRequest.Read("TestObject/Sum");
+                multiRequest.Write("TestObject/C", 4);
+                multiRequest.Meta("TestObject");
+
+                WoopsaMethodArgumentInfo[] argumentInfosSet = new WoopsaMethodArgumentInfo[]
+                {
+                new WoopsaMethodArgumentInfo("a", WoopsaValueType.Real),
+                new WoopsaMethodArgumentInfo("b", WoopsaValueType.Real)
+                };
+                multiRequest.Invoke("TestObject/Set",
+                    argumentInfosSet, 4, 5);
+                multiRequest.Read("TestObject/Sum");
+                multiRequest.Invoke("TestObject/Click",
+                    new Dictionary<string, WoopsaValue>());
+                multiRequest.Read("TestObject/IsClicked");
+                multiRequest.Write("TestObject/IsClicked", false);
+                multiRequest.Read("TestObject/IsClicked");
+
+                WoopsaMethodArgumentInfo[] argumentInfosSetS = new WoopsaMethodArgumentInfo[]
+                {
+                new WoopsaMethodArgumentInfo("value", WoopsaValueType.Text)
+                };
+                multiRequest.Invoke("TestObject/SetS",
+                    argumentInfosSetS, "Hello");
+                multiRequest.Read("TestObject/S");
+                multiRequest.Write("TestObject/S", "ABC");
+                multiRequest.Read("TestObject/S");
+            }
+            client.ExecuteMultiRequest(multiRequest);
+
+        }
         #endregion
 
         #region Inner classes


### PR DESCRIPTION
When Post data is too long to be encoded as FromUrl it uses a Json serialization to support big amont of data