### PR TITLE
Bugfix for Dispose

### DIFF
--- a/Sources/DotNet/Woopsa/Client/WoopsaClientProtocol.cs
+++ b/Sources/DotNet/Woopsa/Client/WoopsaClientProtocol.cs
@@ -299,7 +299,7 @@ namespace Woopsa
                     throw;
             }
         }
-        private void CancelPendingRequests() => _httpClient.CancelPendingRequests();
+        private void CancelPendingRequests() => _httpClient?.CancelPendingRequests();
 
         #endregion
 


### PR DESCRIPTION
Dispose was trowing an null reference exception when no communication was made on the object.
This is the fix.